### PR TITLE
fix(cve): remove spring boot starter web

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,9 +27,9 @@ repositories {
 }
 
 dependencies {
+    implementation("com.fasterxml.jackson.core:jackson-databind:2.17.2")
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("org.springframework.boot:spring-boot-starter-jdbc")
-    implementation("org.springframework.boot:spring-boot-starter-web")
 
     compileOnly("org.projectlombok:lombok")
     runtimeOnly("org.postgresql:postgresql")

--- a/src/main/java/fr/redstom/gravenlevelling/config/JacksonConfig.java
+++ b/src/main/java/fr/redstom/gravenlevelling/config/JacksonConfig.java
@@ -1,0 +1,20 @@
+package fr.redstom.gravenlevelling.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JacksonConfig {
+
+    @Bean
+    public ObjectMapper objectMapper() {
+        // Setup Jackson's ObjectMapper with the same settings
+        // as from Spring Boot Autoconfigure.
+        return new ObjectMapper()
+                .configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
+                .configure(SerializationFeature.WRITE_DURATIONS_AS_TIMESTAMPS, false);
+    }
+}


### PR DESCRIPTION
Remove unused Spring Boot Starter Web, include Jackson Databind instead, with a configuration which is supposed to be similar to the one coming from SBSW autoconfiguration.

It will stop running a Tomcat server on bot startup (which is absolutely unused), reduce the number of reported CVEs by dependabot, and reduce the bot jar size.