### PR TITLE
Counter was wrongly computed

### DIFF
--- a/src/main/java/fr/redstom/asynclevelling/cron/VocalExperienceCron.java
+++ b/src/main/java/fr/redstom/asynclevelling/cron/VocalExperienceCron.java
@@ -41,14 +41,16 @@ public class VocalExperienceCron {
                                 .filter(user -> user.getVoiceState() != null)
                                 .filter(user -> !user.getVoiceState().isDeafened())
                                 .filter(user -> !user.getVoiceState().isMuted())
-                                .peek(_ -> counter.incrementAndGet())
                                 .toList();
 
                 if (members.size() < 2) {
                     continue;
                 }
 
-                members.forEach(member -> memberService.addXp(member, per30sec, "Voice activity"));
+                members.forEach(member -> {
+                    counter.incrementAndGet();
+                    memberService.addXp(member, per30sec, "Voice activity");
+                });
             }
         }
 

--- a/src/main/java/fr/redstom/asynclevelling/cron/VocalExperienceCron.java
+++ b/src/main/java/fr/redstom/asynclevelling/cron/VocalExperienceCron.java
@@ -15,7 +15,6 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
-import java.util.concurrent.atomic.AtomicLong;
 
 @Slf4j
 @Service

--- a/src/main/java/fr/redstom/asynclevelling/cron/VocalExperienceCron.java
+++ b/src/main/java/fr/redstom/asynclevelling/cron/VocalExperienceCron.java
@@ -32,7 +32,7 @@ public class VocalExperienceCron {
     public void compute() {
         log.info("Starting xp experience cron");
 
-        AtomicLong counter = new AtomicLong();
+        long counter = 0L;
         for (Guild guild : bot.getGuilds()) {
             for (VoiceChannel channel : guild.getVoiceChannels()) {
 
@@ -47,13 +47,11 @@ public class VocalExperienceCron {
                     continue;
                 }
 
-                members.forEach(member -> {
-                    counter.incrementAndGet();
-                    memberService.addXp(member, per30sec, "Voice activity");
-                });
+                members.forEach(member -> memberService.addXp(member, per30sec, "Voice activity"));
+                counter += members.size();
             }
         }
 
-        log.info("Xp experience cron complete and {} users updated", counter.get());
+        log.info("Xp experience cron complete and {} users updated", counter);
     }
 }


### PR DESCRIPTION
Variable counter was not correctly computed when a member (undeafed and unmuted) was alone in a voice channel or if all other members were deafed or muted.