### PR TITLE
Prevent level command from being executed on bot

### DIFF
--- a/src/main/java/fr/redstom/asynclevelling/commands/CommandLevel.java
+++ b/src/main/java/fr/redstom/asynclevelling/commands/CommandLevel.java
@@ -57,6 +57,11 @@ public class CommandLevel implements CommandExecutor {
             return;
         }
 
+        if (discordMember.getUser().isBot()) {
+            event.replyEmbeds(EmbedUtils.error("Les bots n'ont pas de niveau").build()).queue();
+            return;
+        }
+
         InteractionHook hook = event.deferReply().complete();
 
         MemberDao member = memberService.getMemberByDiscordMember(discordMember);


### PR DESCRIPTION
As bot can't get XP, a member should not be able to get bot's level with command.